### PR TITLE
Reduce needless copies in the Prozess consumer

### DIFF
--- a/FetchResponse.js
+++ b/FetchResponse.js
@@ -48,7 +48,7 @@ var FetchResponse = function(error, messages){
   this.messages = messages;  // an array of message objects
   this.length = 2;
   _.each(this.messages, function(msg){
-    that.length = msg.toBytes().length;
+    that.length = msg.payload.length+10;
   });
   this.bytesLengthVal = null;
 };
@@ -84,7 +84,7 @@ FetchResponse.fromBytes = function(bytes){
   } else {
     messages = parseMessages(response.body);
   }
-  this.bytesLengthVal = response.toBytes().length;
+  this.bytesLengthVal = response.body.length+6;
 
   return new FetchResponse(response.error, messages);
 };
@@ -97,7 +97,7 @@ var parseMessages = function(body){
   while(body.length > 0){
     try {
       var message = Message.fromBytes(body);
-      body = body.slice(message.toBytes().length);
+      body = body.slice(message.payload.length+10);
       messages.push(message);
     } catch(ex){
       break;


### PR DESCRIPTION
I could never get the performance of Prozess up to what's needed for the topics I'm subscribing to, so I ended up writing [an adapter](https://github.com/uber/kafka-spraynozzle) to solve my particular situation, but it would still be a waste to not have these perf improvements in Prozess so others don't have to make such a leap for a while (or at all, if they have a more predictable source stream).
