### PR TITLE
Bump up dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "underscore": "1.3.3",
-    "buffermaker": "1.0.0",
+    "buffermaker": "1.2.0",
     "binary": "0.3.0",
     "crc32": "0.2.2",
     "buffer-crc32": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "binary": "0.3.0",
     "crc32": "0.2.2",
     "buffer-crc32": "0.2.1",
-    "bignum": "0.6.2",
+    "bignum": "0.9.2",
     "readable-stream": "1.0.26"
   },
   "devDependencies": {


### PR DESCRIPTION
bignum 0.6.2 is not compatible with nodejs 0.12 so I had to bump it up to the latest version (0.9.2)
I also had to bump up buffermaker to use the latest version of bignum

all green! :)