### PR TITLE
Change 'license' field to match the provided MIT license

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "node": ">=0.8.0"
   },
   "author": "Gregg Caines",
-  "license": "BSD",
+  "license": "MIT",
   "homepage": "https://github.com/cainus/Prozess"
 }


### PR DESCRIPTION
`LICENSE.MD` contains the text of the [MIT License](https://opensource.org/licenses/MIT), yet `package.json` says "BSD". This fixes that, alongside with adhering to npm's [SPDX license string requirement](https://spdx.org/licenses/MIT.html).
