### PR TITLE
bump bignum to 0.11.0 to allow compilation on node v4.x and v5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "Mithun Satheesh <mithunsatish@gmail.com> (http://www.linkedin.com/pub/mithun-satheesh/28/89b/a56)"
   ],
   "dependencies": {
-    "underscore": "1.3.3",
-    "buffermaker": "1.2.0",
+    "bignum": "0.11.0",
     "binary": "0.3.0",
-    "crc32": "0.2.2",
     "buffer-crc32": "0.2.1",
-    "bignum": "0.9.2",
-    "readable-stream": "1.0.26"
+    "buffermaker": "1.2.0",
+    "crc32": "0.2.2",
+    "readable-stream": "1.0.26",
+    "underscore": "1.3.3"
   },
   "devDependencies": {
     "istanbul": "0.2.8",


### PR DESCRIPTION
Bignum 0.9.2 fails compilation on node 5.3.0 with the following errors:

https://gist.github.com/lxe/bf2aa2c001c2db06c815

Bumping bignum version in an attempt to fix these errors.
